### PR TITLE
feat: 안전결제현황페이지 추가

### DIFF
--- a/src/main/generated/com/ll/weflea/boundedContext/goods/entity/QGoods.java
+++ b/src/main/generated/com/ll/weflea/boundedContext/goods/entity/QGoods.java
@@ -26,6 +26,8 @@ public class QGoods extends EntityPathBase<Goods> {
 
     public final StringPath area = createString("area");
 
+    public final com.ll.weflea.boundedContext.member.entity.QMember buyer;
+
     //inherited
     public final DateTimePath<java.time.LocalDateTime> createDate = _super.createDate;
 
@@ -65,6 +67,7 @@ public class QGoods extends EntityPathBase<Goods> {
 
     public QGoods(Class<? extends Goods> type, PathMetadata metadata, PathInits inits) {
         super(type, metadata, inits);
+        this.buyer = inits.isInitialized("buyer") ? new com.ll.weflea.boundedContext.member.entity.QMember(forProperty("buyer"), inits.get("buyer")) : null;
         this.member = inits.isInitialized("member") ? new com.ll.weflea.boundedContext.member.entity.QMember(forProperty("member"), inits.get("member")) : null;
     }
 

--- a/src/main/generated/com/ll/weflea/boundedContext/goods/entity/QGoods.java
+++ b/src/main/generated/com/ll/weflea/boundedContext/goods/entity/QGoods.java
@@ -1,0 +1,72 @@
+package com.ll.weflea.boundedContext.goods.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QGoods is a Querydsl query type for Goods
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QGoods extends EntityPathBase<Goods> {
+
+    private static final long serialVersionUID = -397176542L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QGoods goods = new QGoods("goods");
+
+    public final com.ll.weflea.base.entity.QBaseEntity _super = new com.ll.weflea.base.entity.QBaseEntity(this);
+
+    public final StringPath area = createString("area");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createDate = _super.createDate;
+
+    public final StringPath description = createString("description");
+
+    public final ListPath<GoodsImage, QGoodsImage> goodsImages = this.<GoodsImage, QGoodsImage>createList("goodsImages", GoodsImage.class, QGoodsImage.class, PathInits.DIRECT2);
+
+    //inherited
+    public final NumberPath<Long> id = _super.id;
+
+    public final com.ll.weflea.boundedContext.member.entity.QMember member;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> modifyDate = _super.modifyDate;
+
+    public final NumberPath<Integer> price = createNumber("price", Integer.class);
+
+    public final EnumPath<Status> status = createEnum("status", Status.class);
+
+    public final StringPath title = createString("title");
+
+    public QGoods(String variable) {
+        this(Goods.class, forVariable(variable), INITS);
+    }
+
+    public QGoods(Path<? extends Goods> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QGoods(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QGoods(PathMetadata metadata, PathInits inits) {
+        this(Goods.class, metadata, inits);
+    }
+
+    public QGoods(Class<? extends Goods> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.member = inits.isInitialized("member") ? new com.ll.weflea.boundedContext.member.entity.QMember(forProperty("member"), inits.get("member")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/ll/weflea/boundedContext/goods/entity/QGoodsImage.java
+++ b/src/main/generated/com/ll/weflea/boundedContext/goods/entity/QGoodsImage.java
@@ -1,0 +1,74 @@
+package com.ll.weflea.boundedContext.goods.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QGoodsImage is a Querydsl query type for GoodsImage
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QGoodsImage extends EntityPathBase<GoodsImage> {
+
+    private static final long serialVersionUID = 8097113L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QGoodsImage goodsImage = new QGoodsImage("goodsImage");
+
+    public final com.ll.weflea.base.entity.QFile _super = new com.ll.weflea.base.entity.QFile(this);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createDate = _super.createDate;
+
+    //inherited
+    public final StringPath file_type = _super.file_type;
+
+    public final QGoods goods;
+
+    //inherited
+    public final NumberPath<Long> id = _super.id;
+
+    public final StringPath imageLink = createString("imageLink");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> modifyDate = _super.modifyDate;
+
+    //inherited
+    public final StringPath name = _super.name;
+
+    //inherited
+    public final StringPath path = _super.path;
+
+    //inherited
+    public final NumberPath<Integer> type_code = _super.type_code;
+
+    public QGoodsImage(String variable) {
+        this(GoodsImage.class, forVariable(variable), INITS);
+    }
+
+    public QGoodsImage(Path<? extends GoodsImage> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QGoodsImage(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QGoodsImage(PathMetadata metadata, PathInits inits) {
+        this(GoodsImage.class, metadata, inits);
+    }
+
+    public QGoodsImage(Class<? extends GoodsImage> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.goods = inits.isInitialized("goods") ? new QGoods(forProperty("goods"), inits.get("goods")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/ll/weflea/boundedContext/notification/entity/QNotification.java
+++ b/src/main/generated/com/ll/weflea/boundedContext/notification/entity/QNotification.java
@@ -1,0 +1,67 @@
+package com.ll.weflea.boundedContext.notification.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QNotification is a Querydsl query type for Notification
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QNotification extends EntityPathBase<Notification> {
+
+    private static final long serialVersionUID = -1485621870L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QNotification notification = new QNotification("notification");
+
+    public final com.ll.weflea.base.entity.QBaseEntity _super = new com.ll.weflea.base.entity.QBaseEntity(this);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createDate = _super.createDate;
+
+    public final com.ll.weflea.boundedContext.goods.entity.QGoods goods;
+
+    //inherited
+    public final NumberPath<Long> id = _super.id;
+
+    public final com.ll.weflea.boundedContext.member.entity.QMember member;
+
+    public final StringPath message = createString("message");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> modifyDate = _super.modifyDate;
+
+    public final DateTimePath<java.time.LocalDateTime> readDate = createDateTime("readDate", java.time.LocalDateTime.class);
+
+    public QNotification(String variable) {
+        this(Notification.class, forVariable(variable), INITS);
+    }
+
+    public QNotification(Path<? extends Notification> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QNotification(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QNotification(PathMetadata metadata, PathInits inits) {
+        this(Notification.class, metadata, inits);
+    }
+
+    public QNotification(Class<? extends Notification> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.goods = inits.isInitialized("goods") ? new com.ll.weflea.boundedContext.goods.entity.QGoods(forProperty("goods"), inits.get("goods")) : null;
+        this.member = inits.isInitialized("member") ? new com.ll.weflea.boundedContext.member.entity.QMember(forProperty("member"), inits.get("member")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/ll/weflea/boundedContext/wish/entity/QWish.java
+++ b/src/main/generated/com/ll/weflea/boundedContext/wish/entity/QWish.java
@@ -1,0 +1,63 @@
+package com.ll.weflea.boundedContext.wish.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QWish is a Querydsl query type for Wish
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QWish extends EntityPathBase<Wish> {
+
+    private static final long serialVersionUID = -1876905718L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QWish wish = new QWish("wish");
+
+    public final com.ll.weflea.base.entity.QBaseEntity _super = new com.ll.weflea.base.entity.QBaseEntity(this);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createDate = _super.createDate;
+
+    public final com.ll.weflea.boundedContext.goods.entity.QGoods goods;
+
+    //inherited
+    public final NumberPath<Long> id = _super.id;
+
+    public final com.ll.weflea.boundedContext.member.entity.QMember member;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> modifyDate = _super.modifyDate;
+
+    public QWish(String variable) {
+        this(Wish.class, forVariable(variable), INITS);
+    }
+
+    public QWish(Path<? extends Wish> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QWish(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QWish(PathMetadata metadata, PathInits inits) {
+        this(Wish.class, metadata, inits);
+    }
+
+    public QWish(Class<? extends Wish> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.goods = inits.isInitialized("goods") ? new com.ll.weflea.boundedContext.goods.entity.QGoods(forProperty("goods"), inits.get("goods")) : null;
+        this.member = inits.isInitialized("member") ? new com.ll.weflea.boundedContext.member.entity.QMember(forProperty("member"), inits.get("member")) : null;
+    }
+
+}
+

--- a/src/main/java/com/ll/weflea/boundedContext/goods/controller/GoodsController.java
+++ b/src/main/java/com/ll/weflea/boundedContext/goods/controller/GoodsController.java
@@ -106,8 +106,12 @@ public class GoodsController {
     }
 
     @GetMapping("/detail/{id}")
-    public String detail(Model model, @PathVariable("id") Long id) {
+    public String detail(Model model, @PathVariable("id") Long id) throws IOException {
         Goods goods = goodsService.findById(id);
+        ResponseEntity<List<byte[]>> allGoodsImages = goodsService.getAllGoodsImages(goods);
+
+        model.addAttribute("goodsImages", allGoodsImages.getBody());
+
 
         model.addAttribute("goods", goods);
 
@@ -138,5 +142,12 @@ public class GoodsController {
         ResponseEntity<byte[]> goodsImage = goodsService.getGoodsImg(goods);
 
         return goodsImage;
+    }
+
+    @GetMapping("/detail/goodsImage/{id}")
+    public ResponseEntity<List<byte[]>> getAllGoodsImg (@PathVariable("id") Long id) throws IOException {
+        Goods goods = goodsService.findById(id);
+
+        return goodsService.getAllGoodsImages(goods);
     }
 }

--- a/src/main/java/com/ll/weflea/boundedContext/goods/controller/GoodsController.java
+++ b/src/main/java/com/ll/weflea/boundedContext/goods/controller/GoodsController.java
@@ -150,4 +150,5 @@ public class GoodsController {
 
         return goodsService.getAllGoodsImages(goods);
     }
+
 }

--- a/src/main/java/com/ll/weflea/boundedContext/goods/entity/Goods.java
+++ b/src/main/java/com/ll/weflea/boundedContext/goods/entity/Goods.java
@@ -33,13 +33,25 @@ public class Goods extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private Member member;
 
+    @OneToOne(fetch = FetchType.LAZY)
+    private Member buyer;
+
     @OneToMany(mappedBy = "goods")
     private List<GoodsImage> goodsImages = new ArrayList<>();
+
+    public void updateStatusAndBuyer(String status, Member buyer) {
+
+        this.status = Status.valueOf(status);
+        this.buyer = buyer;
+    }
 
     public void updateStatus(String status) {
 
         this.status = Status.valueOf(status);
     }
+
+
+
 
 /*
     // 게시글 수정 메소드

--- a/src/main/java/com/ll/weflea/boundedContext/goods/repository/GoodsRepository.java
+++ b/src/main/java/com/ll/weflea/boundedContext/goods/repository/GoodsRepository.java
@@ -1,10 +1,14 @@
 package com.ll.weflea.boundedContext.goods.repository;
 
 import com.ll.weflea.boundedContext.goods.entity.Goods;
-import com.ll.weflea.boundedContext.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-import java.util.Optional;
+import java.util.List;
 
 public interface GoodsRepository extends JpaRepository<Goods, Long> {
+
+    @Query("SELECT g from Goods g inner join g.buyer b where b.id = :buyerId")
+    List<Goods> findByBuyerId(@Param("buyerId") Long buyerId);
 }

--- a/src/main/java/com/ll/weflea/boundedContext/goods/service/GoodsService.java
+++ b/src/main/java/com/ll/weflea/boundedContext/goods/service/GoodsService.java
@@ -6,26 +6,23 @@ import com.ll.weflea.boundedContext.goods.entity.Goods;
 import com.ll.weflea.boundedContext.goods.entity.GoodsImage;
 import com.ll.weflea.boundedContext.goods.repository.GoodsRepository;
 import com.ll.weflea.boundedContext.member.entity.Member;
-import com.ll.weflea.boundedContext.member.repository.MemberRepository;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.apache.commons.io.FilenameUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
-import java.util.UUID;
 
 
 @Slf4j
@@ -97,5 +94,20 @@ public class GoodsService {
         byte[] imageByteArray = IOUtils.toByteArray(inputStream);
         inputStream.close();
         return new ResponseEntity<>(imageByteArray, HttpStatus.OK);
+    }
+
+    public ResponseEntity<List<byte[]>> getAllGoodsImages(Goods goods) throws IOException {
+        List<byte[]> imageList = new ArrayList<>();
+
+        List<GoodsImage> goodsImages = goods.getGoodsImages();
+
+        for (GoodsImage goodsImage : goodsImages) {
+            InputStream inputStream = new FileInputStream(goodsImage.getPath());
+            byte[] imageByteArray = IOUtils.toByteArray(inputStream);
+            inputStream.close();
+            imageList.add(imageByteArray);
+        }
+
+        return new ResponseEntity<>(imageList, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/ll/weflea/boundedContext/goods/service/GoodsService.java
+++ b/src/main/java/com/ll/weflea/boundedContext/goods/service/GoodsService.java
@@ -80,6 +80,13 @@ public class GoodsService {
         goodsRepository.deleteById(id);
     }
 
+    //안전결제완료되면 상품에 대한 buyer 및 거래상태 설정
+    @Transactional
+    public void updateStatusAndBuyer(Long id, String status, Member buyer) {
+        Goods goods = findById(id);
+        goods.updateStatusAndBuyer(status, buyer);
+    }
+
     @Transactional
     public RsData<Goods> updateStatus(Long id, String status) {
         Goods goods = findById(id);
@@ -87,6 +94,7 @@ public class GoodsService {
 
         return RsData.of("S-1", "거래상태가 " + status + "으로 변경되었습니다.");
     }
+
     public ResponseEntity<byte[]> getGoodsImg(Goods goods) throws IOException {
         GoodsImage goodsImage = goods.getGoodsImages().get(0);
 
@@ -110,4 +118,9 @@ public class GoodsService {
 
         return new ResponseEntity<>(imageList, HttpStatus.OK);
     }
+
+    public List<Goods> findByBuyerId(Long buyerId) {
+        return goodsRepository.findByBuyerId(buyerId);
+    }
+
 }

--- a/src/main/java/com/ll/weflea/boundedContext/member/controller/MemberController.java
+++ b/src/main/java/com/ll/weflea/boundedContext/member/controller/MemberController.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -74,5 +75,12 @@ public class MemberController {
         model.addAttribute("goodsList", goodsList);
 
         return "user/weflea/purchaseStatus";
+    }
+
+    @PostMapping("/me/status/complete/deal/{goodsId}")
+    public String completeDeal(@PathVariable Long goodsId) {
+        goodsService.updateStatus(goodsId, "거래완료");
+
+        return rq.redirectWithMsg("/user/member/me/status", "거래가 정상적으로 성사되었습니다.");
     }
 }

--- a/src/main/java/com/ll/weflea/boundedContext/member/controller/MemberController.java
+++ b/src/main/java/com/ll/weflea/boundedContext/member/controller/MemberController.java
@@ -2,28 +2,24 @@ package com.ll.weflea.boundedContext.member.controller;
 
 import com.ll.weflea.base.rq.Rq;
 import com.ll.weflea.base.rsData.RsData;
+import com.ll.weflea.boundedContext.goods.entity.Goods;
+import com.ll.weflea.boundedContext.goods.service.GoodsService;
 import com.ll.weflea.boundedContext.member.dto.NicknameDto;
 import com.ll.weflea.boundedContext.member.entity.Member;
-import com.ll.weflea.boundedContext.member.entity.ProfileImage;
 import com.ll.weflea.boundedContext.member.service.MemberService;
-import com.ll.weflea.boundedContext.member.service.ProfileImageService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.io.IOUtils;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
+import java.util.List;
 
 @Controller
 @RequestMapping("/user/member")
@@ -32,6 +28,7 @@ import java.io.InputStream;
 public class MemberController {
 
     private final MemberService memberService;
+    private final GoodsService goodsService;
     private final Rq rq;
 
     @GetMapping("login")
@@ -67,5 +64,15 @@ public class MemberController {
             return rq.historyBack(memberRsData);
         }
         return rq.redirectWithMsg("/", memberRsData);
+    }
+
+    @GetMapping("/me/status")
+    public String showPurchaseStatus(@AuthenticationPrincipal User user, Model model) {
+        Member member = memberService.findByUsername(user.getUsername()).orElse(null);
+        List<Goods> goodsList = goodsService.findByBuyerId(member.getId());
+
+        model.addAttribute("goodsList", goodsList);
+
+        return "user/weflea/purchaseStatus";
     }
 }

--- a/src/main/java/com/ll/weflea/boundedContext/pay/Controller/PayController.java
+++ b/src/main/java/com/ll/weflea/boundedContext/pay/Controller/PayController.java
@@ -16,10 +16,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.*;
 
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -137,7 +134,7 @@ public class PayController {
         messageDTO.setWriter("관리자");
         messageDTO.setRoomId(chatRoomId);
         chatService.createChatMessage(messageDTO);
-        goodsService.updateStatus(goodsId, "안전결제중");
+        goodsService.updateStatusAndBuyer(goodsId, "안전결제중", sender);
 
 
         return rq.redirectWithMsg("/user/weflea/detail/" + goodsId, "안전결제가 완료되었습니다.");
@@ -155,4 +152,5 @@ public class PayController {
 
         return "user/pay/fail";
     }
+
 }

--- a/src/main/resources/static/resource/common.css
+++ b/src/main/resources/static/resource/common.css
@@ -217,3 +217,55 @@ html > body .label-text {
     height: 100%;
     object-fit: cover;
 }
+
+
+.img-1{
+    width: auto;
+    border-radius: 10px;
+    cursor: pointer;
+    transition: 0.3s;
+}
+/* 이미지 클릭 시, 밝기 조절 */
+.img-1:hover {opacity: 0.8;}
+
+.modal_detail {
+    display: none; /* 모달창 숨겨 놓기 */
+    position: fixed;
+    z-index: 1; /* 모달창을 제일 앞에 두기 */
+    padding-top: 100px;
+    left: 0; top: 0;
+    width: 100%; height: 100%;
+    overflow: auto; /* 스크롤 허용 auto */
+    cursor: pointer; /* 마우스 손가락모양 */
+    background-color: rgba(0, 0, 0, 0.8);
+}
+/* 모달창 이미지 */
+.modal_detail_content {
+    margin: auto;
+    display: block;
+    width: 50%; height: auto;
+    max-width: 1000px;
+    border-radius: 10px;
+    animation-name: zoom;
+    animation-duration: 0.8s;
+}
+/* 모달창 애니메이션 추가 */
+@keyframes zoom {
+    from {transform: scale(0)}
+    to {transform: scale(1)}
+}
+/* 닫기 버튼 꾸미기 */
+.close_detail {
+    position: absolute;
+    top: 15px;
+    right: 35px;
+    color: #f1f1f1;
+    font-size: 40px;
+    font-weight: bold;
+    transition: 0.3s;
+}
+.close_detail:hover, .close_detail:focus{
+    color: #bbb;
+    text-decoration: none;
+    cursor: pointer;
+}

--- a/src/main/resources/templates/user/weflea/detail.html
+++ b/src/main/resources/templates/user/weflea/detail.html
@@ -51,6 +51,9 @@
                             <input type="hidden" th:value="${goods.price}" id="price" name="price">
                             <span th:text="${goods.price}"></span>원
                         </div>
+                        <div class="h4 has-text-warning text-left border-bottom">
+                            <span th:text="${goods.status.toString()}"></span>
+                        </div>
                     </div>
 
                     <form style="max-width: 400px" method="post" id="statusForm" th:action="@{'/user/weflea/detail/update/' + ${goods.id}}">
@@ -82,13 +85,16 @@
 
                     <div class="flex">
                         <form class="mr-3" th:action="@{/chat/room/{id}(id=${goods.id})}" method="post">
-                            <button type="submit" class="btn btn-light border">채팅하기</button>
+                            <button type="submit" class="btn btn-light border"
+                                    th:disabled="${goods.status.toString() == '거래완료'}">채팅하기</button>
                         </form>
                         <form class="mr-3" th:action="@{/user/wish/add/{id}(id=${goods.id})}" method="post">
-                            <button type="submit" class="btn btn-light border">찜하기</button>
+                            <button type="submit" class="btn btn-light border"
+                                    th:disabled="${goods.status.toString() == '거래완료'}">찜하기</button>
                         </form>
                         <form th:action="@{/pay/{id}(id=${goods.id})}" method="get">
-                            <button type="submit" class="btn btn-light border">안전결제</button>
+                            <button type="submit" class="btn btn-light border"
+                                    th:disabled="${goods.status.toString() == '거래완료'}">안전결제</button>
                         </form>
                         <form th:action="@{/user/weflea/detail/delete/{id}(id=${goods.id})}" method="post" style="margin-left: 200px">
                             <button type="submit" class="btn btn-light border" th:if="${goods.member.username == @rq.member.username}"

--- a/src/main/resources/templates/user/weflea/detail.html
+++ b/src/main/resources/templates/user/weflea/detail.html
@@ -13,6 +13,34 @@
             <div class="col-lg-6">
                 <div class="card-body bg-white mt-0 shadow flex">
                     <div class="text-right">
+                        <div class="goods-img img">
+                            <img class="img-1" id="imgId" th:src="@{|/user/weflea/goodsImage/${goods.id}|}" />
+                            <div class="modal_detail">
+                                <span class="close_detail">&times;</span>
+                                <img class="modal_detail_content" id="img01"/>
+                            </div>
+                            <script>
+                                const modal = document.querySelector(".modal_detail");
+                                const img = document.querySelector(".img-1");
+                                const modal_img = document.querySelector(".modal_detail_content");
+                                const span = document.querySelector(".close_detail");
+
+                                img.addEventListener('click', ()=>{
+                                    modalDisplay("block");
+                                    modal_img.src = img.src;
+                                });
+                                span.addEventListener('click', ()=>{
+                                    modalDisplay("none");
+                                });
+                                modal.addEventListener('click', ()=>{
+                                    modalDisplay("none");
+                                });
+                                function modalDisplay(text){
+                                    modal.style.display = text;
+                                }
+                            </script>
+                        </div>
+
                         <div class="h2 has-text-grey text-left border-bottom">
                             <span th:text="${goods.title}"></span>
                         </div>
@@ -62,7 +90,7 @@
                         <form th:action="@{/pay/{id}(id=${goods.id})}" method="get">
                             <button type="submit" class="btn btn-light border">안전결제</button>
                         </form>
-                        <form th:action="@{/user/weflea/detail/delete/{id}(id=${goods.id})}" method="post" style="margin-left: 300px">
+                        <form th:action="@{/user/weflea/detail/delete/{id}(id=${goods.id})}" method="post" style="margin-left: 200px">
                             <button type="submit" class="btn btn-light border" th:if="${goods.member.username == @rq.member.username}"
                                     onclick="return confirm('해당 게시물을 정말 삭제하시겠습니까?')">게시글 삭제</button>
                         </form>

--- a/src/main/resources/templates/user/weflea/purchaseStatus.html
+++ b/src/main/resources/templates/user/weflea/purchaseStatus.html
@@ -1,0 +1,62 @@
+<html layout:decorate="~{user/layout/layout.html}" />
+
+<head>
+  <title>구매 현황</title>
+</head>
+<body>
+<div><div class="container container-mt">
+  <div class="row justify-content-center">
+    <div class="col-lg-10">
+      <div class="card-body bg-white mt-0 shadow flex">
+        <div>
+          <div class="h2 has-text-grey text-lg-center pb-2 border-bottom">
+            <span>안전결제 현황</span>
+          </div>
+          <table>
+            <thead>
+            <tr>
+              <th class="text-center" th:width="200px">상품 사진</th>
+              <th class="text-center" th:width="350px">제목</th>
+              <th class="text-center" th:width="130px">지역</th>
+              <th class="text-center" th:width="130px">상태</th>
+              <th class="text-center" th:width="200px">등록일</th>
+              <th class="text-center" th:width="200px">거래 완료 신청</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr th:each="goods : ${goodsList}">
+              <td>
+                <div class="goods-img img">
+                  <a th:href="@{|/user/weflea/detail/${goods.id}|}">
+                    <img id="imgId" th:src="@{|/user/weflea/goodsImage/${goods.id}|}"/>
+                  </a>
+                </div>
+              </td>
+              <td class="text-center">
+                <a th:href="@{|/user/weflea/detail/${goods.id}|}" th:text="${goods.title}"></a>
+              </td>
+              <td class="text-center">
+                <a th:href="@{|/user/weflea/detail/${goods.id}|}" th:text="${goods.area}"></a>
+              </td>
+              <td class="text-center">
+                <a th:href="@{|/user/weflea/detail/${goods.id}|}" th:text="${goods.status}"></a>
+              </td>
+              <td class="text-center">
+                <a th:href="@{|/user/weflea/detail/${goods.id}|}" th:text="${#temporals.format(goods.createDate, 'MM-dd HH:mm')}"></a>
+              </td>
+              <td class="text-center">
+                <form th:action="@{/pay/{id}(id=${goods.id})}" method="get">
+                  <button type="submit" class="btn btn-light" onclick="return confirm('상품을 받으셨으면 거래 완료 버튼을 눌러주세요.')">
+                    거래 완료</button>
+                </form>
+              </td>
+            </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+</div>
+</body>

--- a/src/main/resources/templates/user/weflea/purchaseStatus.html
+++ b/src/main/resources/templates/user/weflea/purchaseStatus.html
@@ -10,7 +10,7 @@
       <div class="card-body bg-white mt-0 shadow flex">
         <div>
           <div class="h2 has-text-grey text-lg-center pb-2 border-bottom">
-            <span>안전결제 현황</span>
+            <span>안전결제 내역</span>
           </div>
           <table>
             <thead>
@@ -45,9 +45,10 @@
                 <a th:href="@{|/user/weflea/detail/${goods.id}|}" th:text="${#temporals.format(goods.createDate, 'MM-dd HH:mm')}"></a>
               </td>
               <td class="text-center">
-                <form th:action="@{/pay/{id}(id=${goods.id})}" method="get">
-                  <button type="submit" class="btn btn-light" onclick="return confirm('상품을 받으셨으면 거래 완료 버튼을 눌러주세요.')">
-                    거래 완료</button>
+                <form th:action="@{/user/member/me/status/complete/deal/{id}(id=${goods.id})}" method="post">
+                  <button type="submit" class="btn btn-light" onclick="return confirm('상품을 받으셨으면 거래 완료 버튼을 눌러주세요.')"
+                          th:disabled="${goods.status.toString() == '거래완료'}">
+                    거래완료 신청</button>
                 </form>
               </td>
             </tr>


### PR DESCRIPTION
- 상세페이지 이미지 확대 기능
- 안전결제 시 구매자가 안전결제상태를 확인할 수 있는 페이지 추가
- 구매자가 상품을 받으면 안전결제 내역에서 거래 완료 신청을 누를 수 있도록 버튼 추가
- 거래완료신청버튼을 누르면 상품의 상태가 '거래완료'로 변경